### PR TITLE
Send unregister via AMQP

### DIFF
--- a/src/cloud.h
+++ b/src/cloud.h
@@ -22,8 +22,12 @@
 typedef bool (*cloud_downstream_cb_t) (const char *id, struct l_queue *data,
 				       void *user_data);
 
+typedef void (*cloud_device_removed_cb_t) (const char *id,
+				      void *user_data);
+
 int cloud_set_cbs(cloud_downstream_cb_t on_update,
 		  cloud_downstream_cb_t on_request,
+		  cloud_device_removed_cb_t on_removed,
 		  void *user_data);
 int cloud_start(struct settings *settings);
 void cloud_stop(void);

--- a/src/cloud.h
+++ b/src/cloud.h
@@ -31,3 +31,4 @@ int cloud_publish_data(const char *id, uint8_t sensor_id,
 		       uint8_t value_type,
 		       const knot_value_type *value,
 		       uint8_t kval_len);
+int cloud_unregister_device(const char *id);

--- a/src/device.c
+++ b/src/device.c
@@ -197,7 +197,7 @@ static struct l_dbus_message *method_forget(struct l_dbus *dbus,
 
 	if (device->uuid) {
 		/*
-		 *  At msg.c@proxy_removed() will manage additional
+		 *  At msg.c@on_device_removed() will manage additional
 		 *  KNoT operations sending unregister request if the
 		 *  peer (thing) is connected.
 		 */

--- a/src/device.c
+++ b/src/device.c
@@ -28,7 +28,7 @@
 
 #include "dbus.h"
 #include "settings.h"
-#include "proto.h"
+#include "cloud.h"
 #include "device.h"
 #include "proxy.h"
 
@@ -201,7 +201,7 @@ static struct l_dbus_message *method_forget(struct l_dbus *dbus,
 		 *  KNoT operations sending unregister request if the
 		 *  peer (thing) is connected.
 		 */
-		proto_rmnode_by_uuid(device->uuid);
+		cloud_unregister_device(device->id);
 		/* Reply sent at method_reply */
 		return NULL;
 	}

--- a/src/msg.c
+++ b/src/msg.c
@@ -278,6 +278,9 @@ static bool session_uuid_cmp(const void *entry_data, const void *user_data)
 	const struct session *session = entry_data;
 	const char *uuid = user_data;
 
+	if (!session->uuid)
+		return false;
+
 	return strcmp(session->uuid, uuid) == 0 ? true : false;
 }
 

--- a/src/msg.c
+++ b/src/msg.c
@@ -225,8 +225,8 @@ static bool config_sensor_id_cmp(const void *entry_data, const void *user_data)
 
 static int8_t msg_unregister(struct session *session)
 {
-	int proto_sock;
 	int8_t result;
+	char id[KNOT_ID_LEN];
 
 	if (!session->trusted) {
 		hal_log_info("[session %p] unregister: Permission denied!",
@@ -234,9 +234,10 @@ static int8_t msg_unregister(struct session *session)
 		return KNOT_ERR_PERM;
 	}
 
-	hal_log_info("[session %p] rmnode: %.36s", session, session->uuid);
-	proto_sock = l_io_get_fd(session->proto_channel);
-	result = proto_rmnode(proto_sock, session->uuid, session->token);
+	snprintf(id, sizeof(id), "%016"PRIX64, session->id);
+	hal_log_info("[session %p] rmnode: %s", session, id);
+
+	result = cloud_unregister_device(id);
 	if (result != 0)
 		return result;
 

--- a/src/msg.c
+++ b/src/msg.c
@@ -1330,7 +1330,7 @@ static void unregister_callback(struct l_timeout *timeout, void *user_data)
 	device_forget_destroy(mydevice);
 }
 
-static void proxy_removed(const char *device_id, void *user_data)
+static void on_device_removed(const char *device_id, void *user_data)
 {
 	struct knot_device *device = device_get(device_id);
 	struct mydevice *mydevice = l_queue_find(device_id_list,
@@ -1409,7 +1409,6 @@ static void start_timeout(struct l_timeout *timeout, void *user_data)
 	/* Step1: Getting Cloud (device) proxies using owner credential */
 	proto_set_proxy_handlers(sock,
 				 proxy_added,
-				 proxy_removed,
 				 proxy_ready,
 				 settings);
 
@@ -1485,7 +1484,8 @@ int msg_start(struct settings *settings)
 		goto cloud_fail;
 	}
 
-	err = cloud_set_cbs(on_update_cb, on_request_cb, NULL);
+	err = cloud_set_cbs(on_update_cb, on_request_cb, on_device_removed,
+			    NULL);
 	if (err < 0) {
 		hal_log_error("cloud_set_cbs(): %s", strerror(-err));
 		goto cloud_set_cbs_fail;

--- a/src/proto.c
+++ b/src/proto.c
@@ -415,26 +415,6 @@ int proto_schema(int proto_socket, const char *uuid,
 	return result;
 }
 
-int proto_rmnode(int proto_socket, const char *uuid, const char *token)
-{
-	json_raw_t response = { NULL, 0 };
-	int result, err;
-
-	err = proto->rmnode(proto_socket, uuid, token, &response);
-	if (err < 0) {
-		result = KNOT_ERR_CLOUD_FAILURE;
-		hal_log_error("rmnode() failed %s (%d)", strerror(-err), -err);
-		goto done;
-	}
-
-	result = 0;
-
-done:
-	if (response.data)
-		l_free(response.data);
-	return result;
-}
-
 int proto_set_proxy_handlers(int sock,
 			     proto_proxy_added_func_t added,
 			     proto_proxy_removed_func_t removed,
@@ -455,9 +435,4 @@ int proto_set_proxy_handlers(int sock,
 				      proxy, proxy_destroy);
 
 	return 0;
-}
-
-int proto_rmnode_by_uuid(const char *uuid)
-{
-	return proto_rmnode(proxy->sock, uuid, NULL);
 }

--- a/src/proto.h
+++ b/src/proto.h
@@ -22,8 +22,6 @@
 typedef void (*proto_proxy_added_func_t) (const char *device_id, const char *uuid,
 					  const char *name, bool online,
 					  void *user_data);
-typedef void (*proto_proxy_removed_func_t) (const char *device_id,
-					    void *user_data);
 
 typedef void (*proto_proxy_ready_func_t) (void *user_data);
 typedef bool (*proto_property_changed_func_t) (const char *name,
@@ -91,6 +89,5 @@ int proto_getdata(int proto_sock, char *uuid, char *token,
 
 int proto_set_proxy_handlers(int sock,
 			     proto_proxy_added_func_t added,
-			     proto_proxy_removed_func_t removed,
 			     proto_proxy_ready_func_t ready,
 			     void *user_data);

--- a/src/proto.h
+++ b/src/proto.h
@@ -82,8 +82,6 @@ void proto_close(int proto_socket);
 int proto_mknode(int proto_socket, const char *owner_uuid,
 		 const char *device_name, const char *device_id,
 		 char *uuid, char *token);
-int proto_rmnode(int proto_socket, const char *uuid, const char *token);
-int proto_rmnode_by_uuid(const char *uuid);
 int proto_signin(int proto_socket, const char *uuid, const char *token,
 		 proto_property_changed_func_t prop_cb, void *user_data);
 int proto_schema(int proto_socket, const char *uuid,

--- a/test/mock-connector.py
+++ b/test/mock-connector.py
@@ -1,0 +1,64 @@
+#!/usr/bin/python3
+#
+#  This file is part of the KNOT Project
+#
+#  Copyright (c) 2019, CESAR. All rights reserved.
+#
+#   This library is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   This library is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with this library; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+import pika
+import logging
+
+logging.basicConfig(
+    format='%(asctime)s %(message)s',
+    level=logging.INFO,
+    datefmt='%Y-%m-%d %H:%M:%S')
+
+connection = pika.BlockingConnection(
+    pika.ConnectionParameters(host='localhost'))
+channel = connection.channel()
+
+cloud_exchange = 'cloud'
+fog_exchange = 'fog'
+
+EVENT_UNREGISTER = 'device.unregister'
+KEY_UNREGISTERED = 'device.unregistered'
+
+channel.exchange_declare(exchange=fog_exchange, durable=True,
+exchange_type='topic')
+channel.exchange_declare(exchange=cloud_exchange, durable=True,
+exchange_type='topic')
+
+result = channel.queue_declare('', exclusive=True)
+queue_name = result.method.queue
+
+channel.queue_bind(
+        exchange=cloud_exchange, queue=queue_name, routing_key='device.*')
+
+def callback(ch, method, properties, body):
+    logging.info("%r:%r" % (method.routing_key, body))
+
+    if method.routing_key == EVENT_UNREGISTER:
+        message = body
+        channel.basic_publish(exchange=fog_exchange,
+                              routing_key=KEY_UNREGISTERED, body=message)
+
+    logging.info(" [x] Sent %r" % (message))
+
+channel.basic_consume(
+    queue=queue_name, on_message_callback=callback, auto_ack=True)
+
+logging.info('Listening to messages')
+channel.start_consuming()

--- a/test/mock-connector.py
+++ b/test/mock-connector.py
@@ -36,6 +36,8 @@ fog_exchange = 'fog'
 EVENT_UNREGISTER = 'device.unregister'
 KEY_UNREGISTERED = 'device.unregistered'
 
+EVENT_DATA = 'data.publish'
+
 channel.exchange_declare(exchange=fog_exchange, durable=True,
 exchange_type='topic')
 channel.exchange_declare(exchange=cloud_exchange, durable=True,
@@ -46,6 +48,8 @@ queue_name = result.method.queue
 
 channel.queue_bind(
         exchange=cloud_exchange, queue=queue_name, routing_key='device.*')
+channel.queue_bind(
+        exchange=cloud_exchange, queue=queue_name, routing_key='data.*')
 
 def callback(ch, method, properties, body):
     logging.info("%r:%r" % (method.routing_key, body))
@@ -54,6 +58,8 @@ def callback(ch, method, properties, body):
         message = body
         channel.basic_publish(exchange=fog_exchange,
                               routing_key=KEY_UNREGISTERED, body=message)
+    elif method.routing_key == EVENT_DATA:
+        return None
 
     logging.info(" [x] Sent %r" % (message))
 


### PR DESCRIPTION
This PR closes #11 

How to test:
install pika python package
run: `test/mock-connector.py`
run knotd: `sudo src/knotd -nr -c src/knotd.conf`
register a thing with thing mocked script: `test/test-conn.py --debug`
Use d-feet to remove the device.

Expected result:
the mock-connector should show the messages in json
the test-conn.py should receive unregister request and show
```
DEBUG:root:[payload_len: 0] receive knot_msg = 0x12 (UNREGISTER_REQUEST)
INFO:root:Unregistered
INFO:root:Closing connection
```
And knotd should remove the dbus device in d-feet
