### PR TITLE
Parser json array to queue

### DIFF
--- a/src/cloud.c
+++ b/src/cloud.c
@@ -67,9 +67,9 @@
 
 cloud_cb_t cloud_cb;
 
-static void mydevice_free(void *data)
+static void cloud_device_free(void *data)
 {
-	struct mydevice *mydevice = data;
+	struct cloud_device *mydevice = data;
 
 	if (unlikely(!mydevice))
 		return;
@@ -84,7 +84,7 @@ static void mydevice_free(void *data)
 static void cloud_msg_destroy(struct cloud_msg *msg)
 {
 	if (msg->type == LIST_MSG)
-		l_queue_destroy(msg->list, mydevice_free);
+		l_queue_destroy(msg->list, cloud_device_free);
 	else if (msg->type == UPDATE_MSG || msg->type == REQUEST_MSG)
 		l_queue_destroy(msg->list, l_free);
 
@@ -113,7 +113,7 @@ static int map_routing_key_to_msg_type(const char *routing_key)
 static void *cloud_device_array_foreach(json_object *array_item)
 {
 	json_object *jobjkey;
-	struct mydevice *mydevice;
+	struct cloud_device *mydevice;
 	struct l_queue *schema;
 	const char *id, *name;
 
@@ -135,7 +135,7 @@ static void *cloud_device_array_foreach(json_object *array_item)
 	if (!name)
 		return NULL;
 
-	mydevice = l_new(struct mydevice, 1);
+	mydevice = l_new(struct cloud_device, 1);
 	mydevice->id = l_strdup(id);
 	mydevice->name = l_strdup(name);
 	mydevice->uuid = l_strdup(id);

--- a/src/cloud.h
+++ b/src/cloud.h
@@ -38,7 +38,7 @@ struct cloud_msg {
 	};
 };
 
-struct mydevice {
+struct cloud_device {
 	char *id;
 	char *uuid;
 	char *name;

--- a/src/cloud.h
+++ b/src/cloud.h
@@ -38,6 +38,15 @@ struct cloud_msg {
 	};
 };
 
+struct mydevice {
+	char *id;
+	char *uuid;
+	char *name;
+	bool online;
+	struct l_queue *schema;
+	struct l_timeout *unreg_timeout;
+};
+
 typedef bool (*cloud_cb_t) (const struct cloud_msg *msg, void *user_data);
 
 int cloud_set_read_handler(cloud_cb_t read_handler, void *user_data);

--- a/src/msg.c
+++ b/src/msg.c
@@ -48,7 +48,6 @@
 #include "device.h"
 #include "proxy.h"
 #include "cloud.h"
-#include "parser.h"
 #include "msg.h"
 
 #define MIN(a,b) ((a) < (b) ? (a) : (b))

--- a/src/parser.h
+++ b/src/parser.h
@@ -18,18 +18,13 @@
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
-struct mydevice {
-	char *id;
-	char *uuid;
-	char *name;
-	bool online;
-	struct l_queue *schema;
-	struct l_timeout *unreg_timeout;
-};
+
+typedef void *(*parser_json_array_item_cb) (json_object *array_item);
 
 struct l_queue *parser_schema_to_list(const char *json_str);
 struct l_queue *parser_config_to_list(const char *json_str);
-struct l_queue *parser_mydevices_to_list(json_object *jobj);
+struct l_queue *parser_queue_from_json_array(json_object *jobj,
+				parser_json_array_item_cb foreach_cb);
 
 struct l_queue *parser_request_to_list(json_object *jso);
 json_object *parser_sensorid_to_json(const char *key, struct l_queue *list);


### PR DESCRIPTION
This patch changes a circular dependency between the headers parser.h and cloud.h.
The parser should know nothing about the device that comes from cloud.
Now the msg.c doesn't need to include the parser.h and the parser.c doesn't need to include cloud.h