### PR TITLE
Fix schema response type on message_process

### DIFF
--- a/src/msg.c
+++ b/src/msg.c
@@ -892,7 +892,7 @@ static ssize_t msg_process(struct session *session,
 		result = msg_schema(session, &kreq->schema, false);
 		break;
 	case KNOT_MSG_SCHM_END_REQ:
-		rtype = KNOT_MSG_SCHM_END_REQ;
+		rtype = KNOT_MSG_SCHM_END_RSP;
 		result = msg_schema(session, &kreq->schema, true);
 		if (result != 0)
 			break;


### PR DESCRIPTION
Fix schema response type on message_process function. The type should
be a KNOT_MSG_SCHM_END_RSP instead of a KNOT_MSG_SCHM_END_REQ.