### PR TITLE
Replace 'data' field by 'value' in parser json

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -523,8 +523,8 @@ struct l_queue *parser_update_to_list(json_object *jso)
 
 		sensor_id = json_object_get_int(jobjkey);
 
-		/* Getting 'data' */
-		if (!json_object_object_get_ex(json_data, "data", &jobjkey))
+		/* Getting 'value' */
+		if (!json_object_object_get_ex(json_data, "value", &jobjkey))
 			goto fail;
 
 		jtype = json_object_get_type(jobjkey);

--- a/test/mock-connector.py
+++ b/test/mock-connector.py
@@ -58,7 +58,7 @@ def __parse_update_message(msg_file):
     else:
         msg = {
             "id": "0123456789abcdef",
-            "data": [{"sensor_id": 253, "data": True}]
+            "data": [{"sensor_id": 253, "value": True}]
         }
     return json.dumps(msg)
 


### PR DESCRIPTION
This patch changes the JSON 'value' field parsed in 'update' message to
follow the documentation on knot-fog-connector repository:
https://github.com/CESARBR/knot-fog-connector.