### PR TITLE
Improvements in script test-conn

### DIFF
--- a/test/test-conn.py
+++ b/test/test-conn.py
@@ -202,7 +202,12 @@ def handle_register(msg):
     sensor['sock'] = s
     send_knot_msg_schema(**sensor)
 
-def handle_auth():
+def handle_auth(msg):
+    _, _, result = struct.unpack(HEADER_FMT + 'b', msg)
+    if result < 0:
+        logging.error('Authentication error')
+        send_knot_msg_auth(s, str(credentials['uuid']), str(credentials['token']))
+
     logging.info('Authenticated')
     for data in datas:
         interval = data.pop('interval') if 'interval' in data else 10
@@ -313,7 +318,7 @@ while 1:
     logging.debug('[payload_len: %d] receive knot_msg = 0x%x (%s)', payload_len,
                   msg_type, knot_proto_to_str(msg_type))
     {
-        PROTO_AUTH_RSP: handle_auth,
+        PROTO_AUTH_RSP: lambda: handle_auth(msg),
         PROTO_UNREGISTER_REQ: handle_unregister,
         PROTO_SCHM_FRAG_RSP:lambda: handle_schema(msg),
         PROTO_SCHM_END_RSP: lambda: handle_schema_end(msg),

--- a/test/test-conn.py
+++ b/test/test-conn.py
@@ -168,11 +168,12 @@ def send_knot_msg_auth(sock, uuid, token):
     return sock.send(msg)
 
 def send_knot_msg_schema(sock, sensor_id, value_type, unit, type_id, name):
+    msg_type = PROTO_SCHM_FRAG_REQ if schemas else PROTO_SCHM_END_REQ
     logging.debug('[payload_len: %d] Sending knot_msg 0x%x (%s)', struct.calcsize(SCHEMA_FMT),
-                  PROTO_SCHM_FRAG_REQ, knot_proto_to_str(PROTO_SCHM_FRAG_REQ))
+                  msg_type, knot_proto_to_str(msg_type))
     logging.debug('Schema: %s', json.dumps({'sensor_id': sensor_id, 'value_type': value_type,
                                             'unit': unit, 'type_id': type_id, 'name': name}))
-    header = struct.pack(HEADER_FMT, PROTO_SCHM_FRAG_REQ, struct.calcsize(SCHEMA_FMT))
+    header = struct.pack(HEADER_FMT, msg_type, struct.calcsize(SCHEMA_FMT))
     msg = header + struct.pack('BBB', sensor_id, value_type, unit)
     msg = msg + struct.pack('H', type_id)
     msg = msg + struct.pack('23s', to_string(name))


### PR DESCRIPTION
This PR verifies the error code in knot protocol to retry the schema and auth messages. Also, it fixes the missing `payload_len` field when knotd sends a message to the thing.