### PR TITLE
Fix missing free struct l_timeout

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -39,6 +39,7 @@
 
 static void main_loop_quit(struct l_timeout *timeout, void *user_data)
 {
+	l_timeout_remove(timeout);
 	l_main_quit();
 }
 


### PR DESCRIPTION
This patch fixes the following error:
```
==22439== 32 bytes in 1 blocks are definitely lost in loss record 32 of 60
==22439==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==22439==    by 0x4E482DD: l_malloc (util.c:62)
==22439==    by 0x4E4DFAF: timeout_create_with_nanoseconds (timeout.c:137)
==22439==    by 0x4E4DB31: handle_callback (signal.c:78)
==22439==    by 0x4E4DB31: signalfd_read_cb (signal.c:104)
==22439==    by 0x4E4E322: io_callback (io.c:126)
==22439==    by 0x4E4D5B9: l_main_iterate (main.c:473)
==22439==    by 0x4E4D68B: l_main_run (main.c:520)
==22439==    by 0x4E4D8AA: l_main_run_with_signal (main.c:642)
==22439==    by 0x10BBBA: l_main_loop_run (main.c:75)
==22439==    by 0x10BBBA: main (main.c:141)
```

Calling the function l_timeout_remove to free the struct l_timeout