### PR TITLE
Free uuid and token when unauthorized

### DIFF
--- a/src/msg.c
+++ b/src/msg.c
@@ -1172,6 +1172,10 @@ static bool handle_device_auth(struct session *session, const char *device_id,
 	if (!auth) {
 		hal_log_error("[session %p] Not Authorized", session);
 		msg.action.result = KNOT_ERR_PERM;
+		l_free(session->uuid);
+		l_free(session->token);
+		session->uuid = NULL;
+		session->token = NULL;
 	}
 
 	osent = session->node_ops->send(session->node_fd, &msg,


### PR DESCRIPTION
This patch frees the device credentials to avoid leak memory when the
device is not authorized to post data message.