### PR TITLE
Add parser function to create json_object and rename json_object to create a standard.

### DIFF
--- a/src/cloud.c
+++ b/src/cloud.c
@@ -311,7 +311,7 @@ int cloud_register_device(const char *id, const char *name)
 int cloud_unregister_device(const char *id)
 {
 	amqp_bytes_t queue_cloud;
-	json_object *jobj;
+	json_object *jobj_unreg;
 	const char *json_str;
 	int result;
 
@@ -321,16 +321,15 @@ int cloud_unregister_device(const char *id)
 		return -1;
 	}
 
-	jobj = json_object_new_object();
-	json_object_object_add(jobj, "id", json_object_new_string(id));
-	json_str = json_object_to_json_string(jobj);
+	jobj_unreg = parser_unregister_json_create(id);
+	json_str = json_object_to_json_string(jobj_unreg);
 
 	result = amqp_publish_persistent_message(queue_cloud,
 		AMQP_EXCHANGE_CLOUD, AMQP_CMD_DEVICE_UNREGISTER, json_str);
 	if (result < 0)
 		return KNOT_ERR_CLOUD_FAILURE;
 
-	json_object_put(jobj);
+	json_object_put(jobj_unreg);
 	amqp_bytes_free(queue_cloud);
 
 	return 0;

--- a/src/cloud.c
+++ b/src/cloud.c
@@ -283,6 +283,10 @@ int cloud_register_device(const char *id, const char *name)
 	}
 
 	jobj_device = parser_device_json_create(id, name);
+	if (!jobj_device) {
+		amqp_bytes_free(queue_cloud);
+		return KNOT_ERR_CLOUD_FAILURE;
+	}
 	json_str = json_object_to_json_string(jobj_device);
 
 	result = amqp_publish_persistent_message(queue_cloud,
@@ -322,6 +326,10 @@ int cloud_unregister_device(const char *id)
 	}
 
 	jobj_unreg = parser_unregister_json_create(id);
+	if (!jobj_unreg) {
+		amqp_bytes_free(queue_cloud);
+		return KNOT_ERR_CLOUD_FAILURE;
+	}
 	json_str = json_object_to_json_string(jobj_unreg);
 
 	result = amqp_publish_persistent_message(queue_cloud,
@@ -360,6 +368,10 @@ int cloud_auth_device(const char *id, const char *token)
 	}
 
 	jobj_auth = parser_auth_json_create(id, token);
+	if (!jobj_auth) {
+		amqp_bytes_free(queue_cloud);
+		return KNOT_ERR_CLOUD_FAILURE;
+	}
 	json_str = json_object_to_json_string(jobj_auth);
 
 	result = amqp_publish_persistent_message(queue_cloud,
@@ -398,6 +410,10 @@ int cloud_update_schema(const char *id, struct l_queue *schema_list)
 	}
 
 	jobj_schema = parser_schema_create_object(id, schema_list);
+	if (!jobj_schema) {
+		amqp_bytes_free(queue_cloud);
+		return KNOT_ERR_CLOUD_FAILURE;
+	}
 	json_str = json_object_to_json_string(jobj_schema);
 
 	result = amqp_publish_persistent_message(queue_cloud,
@@ -473,7 +489,10 @@ int cloud_publish_data(const char *id, uint8_t sensor_id, uint8_t value_type,
 	int result;
 
 	jobj_data = parser_data_create_object(id, sensor_id, value_type, value,
-				       kval_len);
+					      kval_len);
+	if (!jobj_data)
+		return KNOT_ERR_CLOUD_FAILURE;
+
 	json_str = json_object_to_json_string(jobj_data);
 
 	queue_cloud = amqp_declare_new_queue(AMQP_QUEUE_CLOUD);

--- a/src/cloud.c
+++ b/src/cloud.c
@@ -349,7 +349,7 @@ int cloud_unregister_device(const char *id)
 int cloud_auth_device(const char *id, const char *token)
 {
 	amqp_bytes_t queue_cloud;
-	json_object *jobj_device;
+	json_object *jobj_auth;
 	const char *json_str;
 	int result;
 
@@ -359,8 +359,8 @@ int cloud_auth_device(const char *id, const char *token)
 		return -1;
 	}
 
-	jobj_device = parser_auth_json_create(id, token);
-	json_str = json_object_to_json_string(jobj_device);
+	jobj_auth = parser_auth_json_create(id, token);
+	json_str = json_object_to_json_string(jobj_auth);
 
 	result = amqp_publish_persistent_message(queue_cloud,
 						 AMQP_EXCHANGE_CLOUD,
@@ -369,7 +369,7 @@ int cloud_auth_device(const char *id, const char *token)
 	if (result < 0)
 		result = KNOT_ERR_CLOUD_FAILURE;
 
-	json_object_put(jobj_device);
+	json_object_put(jobj_auth);
 	amqp_bytes_free(queue_cloud);
 
 	return result;

--- a/src/parser.c
+++ b/src/parser.c
@@ -688,6 +688,25 @@ json_object *parser_auth_json_create(const char *device_id,
 	return auth;
 }
 
+json_object *parser_unregister_json_create(const char *device_id)
+{
+	json_object *unreg;
+
+	unreg = json_object_new_object();
+	if (!unreg)
+		return NULL;
+
+	json_object_object_add(unreg, "id",
+			       json_object_new_string(device_id));
+
+	/*
+	 * Returned JSON object is in the following format:
+	 *
+	 * { "id": "fbe64efa6c7f717e" }
+	 */
+	return unreg;
+}
+
 static json_object *schema_item_create_obj(knot_msg_schema *schema)
 {
 	json_object *json_schema;

--- a/src/parser.h
+++ b/src/parser.h
@@ -39,6 +39,7 @@ json_object *parser_device_json_create(const char *device_id,
 				       const char *device_name);
 json_object *parser_auth_json_create(const char *device_id,
 				     const char *device_token);
+json_object *parser_unregister_json_create(const char *device_id);
 json_object *parser_schema_create_object(const char *device_id,
 					 struct l_queue *schema_list);
 const char *parser_get_key_str_from_json_obj(json_object *jso, const char *key);


### PR DESCRIPTION
Add parser function to create json_object on cloud_unregister_device.
Rename json_object on cloud_auth_device to create a standard.
Closes #43 