### PR TITLE
Handle disconnection and connection retry to AMQP broker

### DIFF
--- a/src/amqp.c
+++ b/src/amqp.c
@@ -359,6 +359,11 @@ amqp_bytes_t amqp_declare_new_queue(const char *name)
 	amqp_bytes_t queue;
 	amqp_queue_declare_ok_t *r;
 
+	if (!amqp_ctx.conn) {
+		queue.bytes = NULL;
+		return queue;
+	}
+
 	r = amqp_queue_declare(amqp_ctx.conn, 1,
 			amqp_cstring_bytes(name),
 			0, /* passive */

--- a/src/amqp.c
+++ b/src/amqp.c
@@ -204,35 +204,27 @@ static void start_connection(struct l_timeout *ltimeout, void *user_data)
 	status = amqp_parse_url(tmp_url, &cinfo);
 	if (status) {
 		hal_log_error("amqp_parse_url: %s", amqp_error_string2(status));
-		l_timeout_modify_ms(ltimeout,
-				    AMQP_CONNECTION_RETRY_TIMEOUT_MS);
-		l_free(tmp_url);
-		return;
+		goto done;
 	}
 
 	amqp_ctx.conn = amqp_new_connection();
+	if (!amqp_ctx.conn) {
+		hal_log_error("amqp_new_connection: Error on creation");
+		goto done;
+	}
 
 	socket = amqp_tcp_socket_new(amqp_ctx.conn);
 	if (!socket) {
-		amqp_destroy_connection(amqp_ctx.conn);
-		amqp_ctx.conn = NULL;
-		hal_log_error("error creating tcp socket\n");
-		l_timeout_modify_ms(ltimeout,
-				    AMQP_CONNECTION_RETRY_TIMEOUT_MS);
-		l_free(tmp_url);
-		return;
+		hal_log_error("error creating tcp socket");
+		goto destroy_conn;
 	}
 
 	status = amqp_socket_open_noblock(socket, cinfo.host, cinfo.port,
 					  &timeout);
-	if (status) {
-		amqp_destroy_connection(amqp_ctx.conn);
-		amqp_ctx.conn = NULL;
-		hal_log_error("error opening socket\n");
-		l_timeout_modify_ms(ltimeout,
-				    AMQP_CONNECTION_RETRY_TIMEOUT_MS);
-		l_free(tmp_url);
-		return;
+	if (status < 0) {
+		hal_log_error("error opening socket: %s",
+					amqp_error_string2(status));
+		goto close_conn;
 	}
 
 	r = amqp_login(amqp_ctx.conn, cinfo.vhost,
@@ -240,30 +232,19 @@ static void start_connection(struct l_timeout *ltimeout, void *user_data)
 			AMQP_DEFAULT_HEARTBEAT, AMQP_SASL_METHOD_PLAIN,
 			cinfo.user, cinfo.password);
 	if (r.reply_type != AMQP_RESPONSE_NORMAL) {
-		amqp_destroy_connection(amqp_ctx.conn);
-		amqp_ctx.conn = NULL;
 		hal_log_error("amqp_login(): %s", amqp_rpc_reply_string(r));
-		l_timeout_modify_ms(ltimeout,
-				    AMQP_CONNECTION_RETRY_TIMEOUT_MS);
-		l_free(tmp_url);
-		return;
+		goto close_conn;
 	}
 
-	hal_log_info("Connected to amqp://%s:%s@%s:%d/%s\n", cinfo.user,
+	hal_log_info("Connected to amqp://%s:%s@%s:%d/%s", cinfo.user,
 		     cinfo.password, cinfo.host, cinfo.port, cinfo.vhost);
 
 	amqp_channel_open(amqp_ctx.conn, 1);
 	r = amqp_get_rpc_reply(amqp_ctx.conn);
 	if (r.reply_type != AMQP_RESPONSE_NORMAL) {
-		amqp_connection_close(amqp_ctx.conn, AMQP_REPLY_SUCCESS);
-		amqp_destroy_connection(amqp_ctx.conn);
-		amqp_ctx.conn = NULL;
 		hal_log_error("amqp_channel_open(): %s",
 				amqp_rpc_reply_string(r));
-		l_timeout_modify_ms(ltimeout,
-				    AMQP_CONNECTION_RETRY_TIMEOUT_MS);
-		l_free(tmp_url);
-		return;
+		goto close_conn;
 	}
 
 	amqp_ctx.amqp_io = l_io_new(amqp_get_sockfd(amqp_ctx.conn));
@@ -271,17 +252,28 @@ static void start_connection(struct l_timeout *ltimeout, void *user_data)
 	status = l_io_set_disconnect_handler(amqp_ctx.amqp_io, on_disconnect,
 					     NULL, NULL);
 	if (!status) {
-		amqp_connection_close(amqp_ctx.conn, AMQP_REPLY_SUCCESS);
-		amqp_destroy_connection(amqp_ctx.conn);
-		l_io_destroy(amqp_ctx.amqp_io);
-		amqp_ctx.conn = NULL;
-		amqp_ctx.amqp_io = NULL;
 		hal_log_error("Error on set up disconnect handler");
-		l_timeout_modify_ms(ltimeout,
-				    AMQP_CONNECTION_RETRY_TIMEOUT_MS);
-		l_free(tmp_url);
-		return;
+		goto io_destroy;
 	}
+	goto done;
+
+io_destroy:
+	l_io_destroy(amqp_ctx.amqp_io);
+	amqp_ctx.amqp_io = NULL;
+close_conn:
+	r = amqp_connection_close(amqp_ctx.conn, AMQP_REPLY_SUCCESS);
+	if (r.reply_type != AMQP_RESPONSE_NORMAL)
+		hal_log_error("amqp_connection_close: %s",
+				amqp_rpc_reply_string(r));
+destroy_conn:
+	status = amqp_destroy_connection(amqp_ctx.conn);
+	if (status < 0)
+		hal_log_error("status destroy: %s", amqp_error_string2(status));
+
+	amqp_ctx.conn = NULL;
+	l_timeout_modify_ms(ltimeout, AMQP_CONNECTION_RETRY_TIMEOUT_MS);
+done:
+	l_free(tmp_url);
 }
 
 /**

--- a/src/amqp.h
+++ b/src/amqp.h
@@ -23,13 +23,15 @@ typedef bool (*amqp_read_cb_t) (const char *exchange,
 				   const char *routing_key,
 				   const char *body,
 				   void *user_data);
+typedef void (*amqp_connected_cb_t) (void *user_data);
 
 int amqp_set_queue_to_consume(amqp_bytes_t queue,
 			      const char *exchange,
 			      const char *routing_key);
 amqp_bytes_t amqp_declare_new_queue(const char *name);
 int amqp_set_read_cb(amqp_read_cb_t on_read, void *user_data);
-int amqp_start(struct settings *settings);
+int amqp_start(struct settings *settings, amqp_connected_cb_t connected_cb,
+	       void *user_data);
 void amqp_stop(void);
 int8_t amqp_publish_persistent_message(amqp_bytes_t queue, const char *exchange,
 		const char *routing_keys, const char *body);

--- a/src/cloud.c
+++ b/src/cloud.c
@@ -548,9 +548,10 @@ int cloud_set_read_handler(cloud_cb_t read_handler, void *user_data)
 	return 0;
 }
 
-int cloud_start(struct settings *settings)
+int cloud_start(struct settings *settings, cloud_connected_cb_t connected_cb,
+		void *user_data)
 {
-	return amqp_start(settings);
+	return amqp_start(settings, connected_cb, user_data);
 }
 
 void cloud_stop(void)

--- a/src/cloud.h
+++ b/src/cloud.h
@@ -48,9 +48,11 @@ struct cloud_device {
 };
 
 typedef bool (*cloud_cb_t) (const struct cloud_msg *msg, void *user_data);
+typedef void (*cloud_connected_cb_t) (void *user_data);
 
 int cloud_set_read_handler(cloud_cb_t read_handler, void *user_data);
-int cloud_start(struct settings *settings);
+int cloud_start(struct settings *settings, cloud_connected_cb_t connected_cb,
+		void *user_data);
 void cloud_stop(void);
 int cloud_publish_data(const char *id, uint8_t sensor_id,
 		       uint8_t value_type,

--- a/src/msg.c
+++ b/src/msg.c
@@ -542,8 +542,10 @@ static int8_t msg_auth(struct session *session,
 	session->rollback = 0; /* Rollback disabled */
 
 	if (result != 0) {
+		l_free(session->uuid);
 		l_free(session->token);
 		session->token = NULL;
+		session->uuid = NULL;
 		return result;
 	}
 

--- a/src/msg.c
+++ b/src/msg.c
@@ -446,8 +446,10 @@ static int8_t msg_register(struct session *session,
 	snprintf(id, sizeof(id), "%016"PRIx64, kreq->id);
 
 	result = cloud_register_device(id, device_name);
-	if (result != 0)
+	if (result != 0) {
+		cloud_device_free(device_pending);
 		return result;
+	}
 
 	device_pending->id = l_strdup(id);
 	/**


### PR DESCRIPTION
This patch handles disconnection from `amqp-server` and tries to connect again.

How to test:

1. Stop rabbitmq-server:
`sudo systemctl stop rabbitmq-server.service`
2. Start knotd:
`sudo src/knotd -nr`
3. Verify if knotd retries to start a connection. Also, try to run the script `test-conn`. It shouldn't accept the thing.
4. Start rabbitmq-server:
`sudo rabbitmq-server`
5. Verify if knotd printed:
`CLOUD CONNECTED`
6. Run the test scripts `mock-connector`:
`test/mock-connector listen`
7. Verify if knotd creates the device dbus.
8. Stop the rabbitmq-server created on step 4
9. Verify that knotd try to reconnect to rabbitmq and script `test/mock-connector` crashed
10. Repeat step 4 but after step 6 run the `test/test-conn` script
11. Verify if the connection was successful