### PR TITLE
Rename queue and exchange on AMQP API

### DIFF
--- a/src/cloud.c
+++ b/src/cloud.c
@@ -41,12 +41,12 @@
 #include "parser.h"
 #include "cloud.h"
 
-#define MQ_QUEUE_FOG "fog-messages"
-#define MQ_QUEUE_CLOUD "cloud-messages"
+#define MQ_QUEUE_FOG "connOut-messages"
+#define MQ_QUEUE_CLOUD "connIn-messages"
 
 /* Exchanges */
-#define MQ_EXCHANGE_FOG "fog"
-#define MQ_EXCHANGE_CLOUD "cloud"
+#define MQ_EXCHANGE_FOG "connOut"
+#define MQ_EXCHANGE_CLOUD "connIn"
 
 /* Headers */
 #define MQ_AUTHORIZATION_HEADER "Authorization"

--- a/test/mock-connector.py
+++ b/test/mock-connector.py
@@ -24,10 +24,10 @@ import json
 import argparse
 import secrets
 
-cloud_exchange = 'cloud'
-fog_exchange = 'fog'
+cloud_exchange = 'connIn'
+fog_exchange = 'connOut'
 
-QUEUE_CLOUD_NAME = 'cloud-messages'
+QUEUE_CLOUD_NAME = 'connIn-messages'
 
 EVENT_REGISTER = 'device.register'
 KEY_REGISTERED = 'device.registered'


### PR DESCRIPTION
This patch changes the queue and exchange name due to connector API
changes.