### PR TITLE
Fix the crash when send unregister message in rollback

### DIFF
--- a/src/msg.c
+++ b/src/msg.c
@@ -715,13 +715,6 @@ static ssize_t msg_process(struct session *session,
 		if (result != 0)
 			break;
 
-		if (session->schema_timeout)
-			l_timeout_remove(session->schema_timeout);
-
-		session->schema_timeout =
-			l_timeout_create_ms(512,
-					    schema_rollback_cb,
-					    session, NULL);
 		return 0;
 	case KNOT_MSG_UNREG_REQ:
 		result = msg_unregister(session);
@@ -998,6 +991,13 @@ send:
 		err = -osent;
 		hal_log_error("[session %p] Can't send register response %s(%d)"
 			      , session, strerror(err), err);
+	} else if (!error) {
+		if (session->schema_timeout)
+			l_timeout_remove(session->schema_timeout);
+
+		session->schema_timeout = l_timeout_create_ms(512,
+							schema_rollback_cb,
+							session, NULL);
 	}
 
 	return true;

--- a/src/msg.c
+++ b/src/msg.c
@@ -510,6 +510,8 @@ static int8_t msg_schema(struct session *session,
 		return KNOT_ERR_PERM;
 	}
 
+	session->rollback = 1; /* Reset schema rollback ticks */
+
 	/*
 	 * {
 	 *	"schema" : [

--- a/src/msg.c
+++ b/src/msg.c
@@ -474,8 +474,6 @@ static int8_t msg_auth(struct session *session,
 	session->device_req_auth = true;
 	result = cloud_auth_device(mydevice->id, token);
 
-	session->rollback = 0; /* Rollback disabled */
-
 	if (result != 0) {
 		l_free(session->uuid);
 		l_free(session->token);
@@ -738,15 +736,6 @@ static ssize_t msg_process(struct session *session,
 		rtype = KNOT_MSG_AUTH_RSP;
 		if (result != 0)
 			break;
-
-		if (session->schema_timeout)
-			l_timeout_remove(session->schema_timeout);
-
-		/* Enable downstream after authentication */
-		session->schema_timeout =
-			l_timeout_create_ms(512,
-					    schema_rollback_cb,
-					    session, NULL);
 		/*
 		 * KNOT_MSG_AUTH_RSP is sent on function
 		 * handle_device_auth


### PR DESCRIPTION
This PR: 
Reorder functions and fix the behavior of schema rollback.
Now, schema rollback timeout is created only after a response of registration from the cloud and just sends an unregister message if the device is already registered.

Closes #67 